### PR TITLE
Fixed redirect string building

### DIFF
--- a/routes/spotify.js
+++ b/routes/spotify.js
@@ -147,13 +147,13 @@ router.get('/callback', function(req, res) {
 				});
 
 				// we can also pass the token to the browser to make requests from there
-				res.redirect(`${process.env.SPOTIFY_REDIRECT}/spotify?` + // Redirects to playground/spotify (was /#)
+				res.redirect(`${process.env.SPOTIFY_REDIRECT}?` + // Redirects to playground/spotify (was /#)
 					querystring.stringify({
 						access_token: access_token,
 						refresh_token: refresh_token
 					}));
 			} else {
-				res.redirect(`${process.env.SPOTIFY_REDIRECT}/spotify?` + // Redirects to playground/spotify (was /#)
+				res.redirect(`${process.env.SPOTIFY_REDIRECT}?` + // Redirects to playground/spotify (was /#)
 					querystring.stringify({
 						error: 'invalid_token'
 					}));


### PR DESCRIPTION
- Appending '/spotify?' wasn't a good idea...
- Testing on GH Pages while Heroku deployment is borked,
- and GH Pages is case-sensitive with URLs.
- Makes far more sense to set the whole URL in the .env